### PR TITLE
Add localized SEO metadata and routing

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -12,16 +12,101 @@
     <meta name="keywords" content="перманентный макияж Краков, перманент бровей, перманент губ, микроблейдинг, татуаж, пудровые брови, lip blush" />
     
     <link rel="canonical" href="https://magerovska.com/" />
+    <link rel="alternate" hreflang="x-default" href="https://magerovska.com/" />
+    <link rel="alternate" hreflang="ru" href="https://magerovska.com/" />
+    <link rel="alternate" hreflang="pl" href="https://magerovska.com/pl" />
+    <link rel="alternate" hreflang="en" href="https://magerovska.com/en" />
+    <link rel="alternate" hreflang="ua" href="https://magerovska.com/ua" />
     <link rel="icon" type="image/png" href="/favicon.png" />
-    
+
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Playfair+Display:wght@400;600;700&display=swap" rel="stylesheet">
+
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": ["BeautySalon", "LocalBusiness"],
+        "@id": "https://magerovska.com/#magerovska-permanent",
+        "name": "Magerovska Permanent",
+        "image": "https://magerovska.com/og-image.jpg",
+        "description": "Профессиональный перманентный макияж в Кракове: брови, губы, межресничка. Сертифицированные пигменты и индивидуальный подход.",
+        "url": "https://magerovska.com/",
+        "telephone": "+380938203764",
+        "priceRange": "200-500 PLN",
+        "address": {
+          "@type": "PostalAddress",
+          "streetAddress": "Kamienna 19b, lokal L3",
+          "addressLocality": "Kraków",
+          "postalCode": "30-001",
+          "addressRegion": "Małopolskie",
+          "addressCountry": "PL"
+        },
+        "geo": {
+          "@type": "GeoCoordinates",
+          "latitude": "50.074180",
+          "longitude": "19.944990"
+        },
+        "openingHoursSpecification": [
+          {
+            "@type": "OpeningHoursSpecification",
+            "dayOfWeek": ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday"],
+            "opens": "09:00",
+            "closes": "18:00"
+          }
+        ],
+        "sameAs": [
+          "https://instagram.com/magerovska_permanent",
+          "https://wa.me/380938203764",
+          "https://t.me/magerovska_permanent",
+          "https://theahstudio.booksy.com"
+        ],
+        "makesOffer": [
+          {
+            "@type": "Offer",
+            "priceCurrency": "PLN",
+            "price": "450",
+            "availability": "https://schema.org/InStock",
+            "url": "https://magerovska.com/services/eyebrows",
+            "itemOffered": {
+              "@type": "Service",
+              "name": "Перманентный макияж бровей",
+              "description": "Волосковая техника, пудровые и омбре брови с естественным результатом.",
+              "serviceType": "Permanent Eyebrow Makeup"
+            }
+          },
+          {
+            "@type": "Offer",
+            "priceCurrency": "PLN",
+            "price": "450",
+            "availability": "https://schema.org/InStock",
+            "url": "https://magerovska.com/services/lips",
+            "itemOffered": {
+              "@type": "Service",
+              "name": "Перманентный макияж губ",
+              "description": "Lip blush и контур для выразительных и ухоженных губ.",
+              "serviceType": "Permanent Lip Makeup"
+            }
+          },
+          {
+            "@type": "Offer",
+            "priceCurrency": "PLN",
+            "price": "350",
+            "availability": "https://schema.org/InStock",
+            "url": "https://magerovska.com/services/eyeliner",
+            "itemOffered": {
+              "@type": "Service",
+              "name": "Перманентная межресничка",
+              "description": "Аккуратная стрелка и межресничное заполнение для выразительного взгляда.",
+              "serviceType": "Permanent Eyeliner"
+            }
+          }
+        ]
+      }
+    </script>
   </head>
   <body>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
-    <!-- This is a replit script which adds a banner on the top of the page when opened in development mode outside the replit environment -->
-    <script type="text/javascript" src="https://replit.com/public/js/replit-dev-banner.js"></script>
   </body>
 </html>

--- a/client/index.html
+++ b/client/index.html
@@ -16,7 +16,7 @@
     <link rel="alternate" hreflang="ru" href="https://magerovska.com/" />
     <link rel="alternate" hreflang="pl" href="https://magerovska.com/pl" />
     <link rel="alternate" hreflang="en" href="https://magerovska.com/en" />
-    <link rel="alternate" hreflang="ua" href="https://magerovska.com/ua" />
+    <link rel="alternate" hreflang="uk" href="https://magerovska.com/ua" />
     <link rel="icon" type="image/png" href="/favicon.png" />
 
     <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -64,6 +64,7 @@
         "makesOffer": [
           {
             "@type": "Offer",
+            "@id": "https://magerovska.com/#offer-eyebrows",
             "priceCurrency": "PLN",
             "price": "450",
             "availability": "https://schema.org/InStock",
@@ -77,6 +78,7 @@
           },
           {
             "@type": "Offer",
+            "@id": "https://magerovska.com/#offer-lips",
             "priceCurrency": "PLN",
             "price": "450",
             "availability": "https://schema.org/InStock",
@@ -90,6 +92,7 @@
           },
           {
             "@type": "Offer",
+            "@id": "https://magerovska.com/#offer-eyeliner",
             "priceCurrency": "PLN",
             "price": "350",
             "availability": "https://schema.org/InStock",

--- a/client/public/404.html
+++ b/client/public/404.html
@@ -1,0 +1,108 @@
+<!DOCTYPE html>
+<html lang="ru">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Страница не найдена | Magerovska Permanent</title>
+    <style>
+      :root {
+        color-scheme: light;
+      }
+      body {
+        margin: 0;
+        font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        background: linear-gradient(135deg, #f7ebe7, #fef7f5);
+        color: #1f1f1f;
+        min-height: 100vh;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 24px;
+      }
+      .card {
+        max-width: 600px;
+        width: 100%;
+        background: #ffffff;
+        border-radius: 24px;
+        padding: 40px;
+        box-shadow: 0 20px 50px rgba(0, 0, 0, 0.08);
+        text-align: center;
+      }
+      .badge {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 56px;
+        height: 56px;
+        border-radius: 999px;
+        background: rgba(227, 126, 115, 0.15);
+        color: #e37e73;
+        font-size: 28px;
+        margin-bottom: 24px;
+      }
+      h1 {
+        font-size: 28px;
+        margin: 0 0 16px;
+      }
+      p {
+        margin: 0 auto 32px;
+        color: #4b4b4b;
+        line-height: 1.5;
+        max-width: 460px;
+      }
+      .actions {
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+      }
+      .actions a {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        gap: 8px;
+        padding: 14px 20px;
+        border-radius: 999px;
+        text-decoration: none;
+        font-weight: 600;
+        transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+      }
+      .actions a.primary {
+        background: #e37e73;
+        color: #ffffff;
+        box-shadow: 0 10px 20px rgba(227, 126, 115, 0.25);
+      }
+      .actions a.primary:hover {
+        transform: translateY(-2px);
+        box-shadow: 0 14px 30px rgba(227, 126, 115, 0.35);
+      }
+      .actions a.secondary {
+        border: 1px solid rgba(227, 126, 115, 0.35);
+        color: #e37e73;
+        background: #fff5f3;
+      }
+      .actions a.secondary:hover {
+        background: #ffe9e4;
+      }
+      @media (min-width: 480px) {
+        .actions {
+          flex-direction: row;
+          justify-content: center;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="card" role="alert">
+      <div class="badge" aria-hidden="true">404</div>
+      <h1>Страница не найдена</h1>
+      <p>
+        К сожалению, нужная страница недоступна. Вы можете вернуться на главную или сразу перейти к форме связи,
+        чтобы записаться на консультацию.
+      </p>
+      <div class="actions">
+        <a class="primary" href="/">⟵ На главную</a>
+        <a class="secondary" href="/#contact">Связаться с мастером</a>
+      </div>
+    </div>
+  </body>
+</html>

--- a/client/public/robots.txt
+++ b/client/public/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://magerovska-permanent.com/sitemap.xml
+Sitemap: https://magerovska.com/sitemap.xml

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -9,6 +9,12 @@ import Eyebrows from "@/pages/eyebrows";
 import Lips from "@/pages/lips";
 import Eyeliner from "@/pages/eyeliner";
 import NotFound from "@/pages/not-found";
+import { withLocalizedLanguage } from "@/pages/localized-page";
+
+const LocalizedHome = withLocalizedLanguage(Home);
+const LocalizedEyebrows = withLocalizedLanguage(Eyebrows);
+const LocalizedLips = withLocalizedLanguage(Lips);
+const LocalizedEyeliner = withLocalizedLanguage(Eyeliner);
 
 function Router() {
   return (
@@ -19,6 +25,10 @@ function Router() {
       <Route path="/services/eyebrows" component={Eyebrows} />
       <Route path="/services/lips" component={Lips} />
       <Route path="/services/eyeliner" component={Eyeliner} />
+      <Route path="/:lang/services/eyebrows" component={LocalizedEyebrows} />
+      <Route path="/:lang/services/lips" component={LocalizedLips} />
+      <Route path="/:lang/services/eyeliner" component={LocalizedEyeliner} />
+      <Route path="/:lang" component={LocalizedHome} />
       <Route component={NotFound} />
     </Switch>
   );

--- a/client/src/components/hero.tsx
+++ b/client/src/components/hero.tsx
@@ -14,17 +14,17 @@ export default function Hero() {
   };
 
   return (
-    <section 
-      className="relative h-screen flex items-center justify-center overflow-hidden" 
+    <section
+      className="relative h-screen flex items-center justify-center overflow-hidden"
       data-testid="hero-section"
-      style={{
-        backgroundImage: `url(${heroImage})`,
-        backgroundSize: 'cover',
-        backgroundPosition: 'center',
-        backgroundRepeat: 'no-repeat'
-      }}
     >
-      <div className="absolute inset-0 bg-black/30"></div>
+      <img
+        src={heroImage}
+        alt={t('hero.imageAlt')}
+        className="absolute inset-0 h-full w-full object-cover"
+        loading="eager"
+      />
+      <div className="absolute inset-0 bg-black/30" aria-hidden="true"></div>
       
 
       {/* Hero Text positioned at the bottom center */}

--- a/client/src/components/navigation.tsx
+++ b/client/src/components/navigation.tsx
@@ -1,12 +1,16 @@
 import { useState, useEffect } from "react";
+import type { MouseEvent as ReactMouseEvent } from "react";
 import { Menu, X, ChevronDown } from "lucide-react";
+import { Link, useLocation } from "wouter";
 import { Button } from "@/components/ui/button";
 import { useLanguage, Language } from "@/contexts/LanguageContext";
+import { getLocalizedPath, stripLocaleFromPath } from "@/utils/languagePaths";
 
 export default function Navigation() {
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
   const [isLanguageDropdownOpen, setIsLanguageDropdownOpen] = useState(false);
   const { language, setLanguage, t } = useLanguage();
+  const [location, setLocation] = useLocation();
 
   const languages = [
     { code: 'ru' as Language, name: 'RU', flag: '🇷🇺' },
@@ -37,15 +41,60 @@ export default function Navigation() {
     setIsMobileMenuOpen(false);
   };
 
+  const homePath = getLocalizedPath(language, '/');
+
+  const handleLogoClick = (event: ReactMouseEvent<HTMLAnchorElement>) => {
+    event.preventDefault();
+
+    const targetPath = homePath;
+    const currentPath = location || '/';
+
+    if (currentPath === targetPath) {
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    } else {
+      setLocation(targetPath);
+      requestAnimationFrame(() => {
+        window.scrollTo({ top: 0, behavior: 'smooth' });
+      });
+    }
+
+    setIsMobileMenuOpen(false);
+    setIsLanguageDropdownOpen(false);
+  };
+
+  const handleLanguageChange = (lang: Language) => {
+    const currentPath = location || '/';
+    const normalizedPath = stripLocaleFromPath(currentPath);
+    const targetPath = getLocalizedPath(lang, normalizedPath);
+
+    setLanguage(lang);
+    setIsLanguageDropdownOpen(false);
+
+    if (targetPath !== currentPath) {
+      setLocation(targetPath);
+    }
+
+    requestAnimationFrame(() => {
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    });
+  };
+
   return (
     <>
       <nav className="fixed top-0 left-0 right-0 z-50 bg-black bg-opacity-20 backdrop-blur-md border-b border-white border-opacity-10" data-testid="navbar-main">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex justify-between items-center h-16">
             {/* Logo */}
-            <div className="text-white text-xl" style={{ fontFamily: 'LiuJianMaoCao, cursive' }} data-testid="logo-main">
+            <Link
+              href={homePath}
+              className="text-white text-xl focus:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-black"
+              style={{ fontFamily: 'LiuJianMaoCao, cursive' }}
+              data-testid="logo-main"
+              aria-label="Go to homepage"
+              onClick={handleLogoClick}
+            >
               Magerovska Permanent
-            </div>
+            </Link>
 
             {/* Desktop Navigation */}
             <div className="hidden md:flex space-x-8">
@@ -98,10 +147,7 @@ export default function Navigation() {
                     {languages.map((lang) => (
                       <button
                         key={lang.code}
-                        onClick={() => {
-                          setLanguage(lang.code);
-                          setIsLanguageDropdownOpen(false);
-                        }}
+                        onClick={() => handleLanguageChange(lang.code)}
                         className={`w-full px-4 py-2 text-left border-t-2 border-transparent hover:border-gray-900 hover:bg-gray-50 transition-colors ${
                           language === lang.code ? 'bg-gray-100 font-medium' : ''
                         }`}

--- a/client/src/components/seo.tsx
+++ b/client/src/components/seo.tsx
@@ -91,7 +91,7 @@ function updateAlternateLinks(_currentLang: Language, baseUrl: string, pathname:
   const normalizedPath = stripLocaleFromPath(pathname);
 
   // Remove legacy hreflang entries that may remain from previous deployments
-  document.querySelectorAll('link[rel="alternate"][hreflang="uk"]').forEach((node) => node.remove());
+  document.querySelectorAll('link[rel="alternate"][hreflang="ua"]').forEach((node) => node.remove());
 
   languages.forEach((lang) => {
     const hreflang = getHrefLang(lang);
@@ -155,8 +155,11 @@ function createLocalBusinessData(language: Language, description: string, baseUr
     const servicePath = `/services/${service}`;
     const serviceUrl = getLocalizedUrl(language, servicePath, baseUrl);
 
+    const offerId = `${businessUrl}#offer-${service}`;
+
     return {
       '@type': 'Offer',
+      '@id': offerId,
       'priceCurrency': 'PLN',
       'price': getServicePrice(service),
       'availability': 'https://schema.org/InStock',

--- a/client/src/components/seo.tsx
+++ b/client/src/components/seo.tsx
@@ -1,5 +1,8 @@
 import { useEffect } from 'react';
-import { useLanguage } from '@/contexts/LanguageContext';
+import { useLanguage, Language } from '@/contexts/LanguageContext';
+import { getHrefLang, getLocalizedPath, getLocalizedUrl, stripLocaleFromPath } from '@/utils/languagePaths';
+
+type ServiceLabelKey = 'duration' | 'healing' | 'lasting';
 
 interface SEOProps {
   title?: string;
@@ -7,6 +10,7 @@ interface SEOProps {
   keywords?: string;
   ogImage?: string;
   canonicalUrl?: string;
+  structuredData?: Array<Record<string, any>>;
 }
 
 export default function SEO({
@@ -14,7 +18,8 @@ export default function SEO({
   description,
   keywords,
   ogImage = '/og-image.jpg',
-  canonicalUrl
+  canonicalUrl,
+  structuredData,
 }: SEOProps) {
   const { t, language } = useLanguage();
 
@@ -25,12 +30,12 @@ export default function SEO({
   const baseUrl = typeof window !== 'undefined' ? window.location.origin : 'https://magerovska.com';
   const pathname = typeof window !== 'undefined' ? window.location.pathname : '/';
   const canonical = canonicalUrl || `${baseUrl}${pathname}`;
-  const siteUrl = canonical;
+  const structuredDataSignature = JSON.stringify(structuredData ?? []);
 
   useEffect(() => {
     document.title = seoTitle;
     document.documentElement.lang = language;
-    
+
     updateMetaTag('name', 'description', seoDescription);
     updateMetaTag('name', 'keywords', seoKeywords);
     
@@ -46,13 +51,13 @@ export default function SEO({
     updateMetaTag('name', 'twitter:title', seoTitle);
     updateMetaTag('name', 'twitter:description', seoDescription);
     updateMetaTag('name', 'twitter:image', `${baseUrl}${ogImage}`);
-    
+
     updateLinkTag('canonical', canonical);
-    
+
     updateAlternateLinks(language, baseUrl, pathname);
-    
-    updateStructuredData(language, seoTitle, seoDescription);
-  }, [seoTitle, seoDescription, seoKeywords, ogImage, canonical, language, siteName, baseUrl, pathname]);
+
+    updateStructuredData(language, seoDescription, baseUrl, structuredData ?? []);
+  }, [seoTitle, seoDescription, seoKeywords, ogImage, canonical, language, siteName, baseUrl, pathname, structuredDataSignature]);
 
   return null;
 }
@@ -81,102 +86,155 @@ function updateLinkTag(rel: string, href: string) {
   element.setAttribute('href', href);
 }
 
-function updateAlternateLinks(currentLang: string, baseUrl: string, pathname: string) {
-  const languages = ['ru', 'pl', 'en', 'uk'];
-  
-  languages.forEach(lang => {
-    const hreflang = lang === 'en' ? 'en' : lang;
-    let element = document.querySelector(`link[hreflang="${hreflang}"]`) as HTMLLinkElement;
-    
+function updateAlternateLinks(_currentLang: Language, baseUrl: string, pathname: string) {
+  const languages: Language[] = ['ru', 'pl', 'en', 'uk'];
+  const normalizedPath = stripLocaleFromPath(pathname);
+
+  // Remove legacy hreflang entries that may remain from previous deployments
+  document.querySelectorAll('link[rel="alternate"][hreflang="uk"]').forEach((node) => node.remove());
+
+  languages.forEach((lang) => {
+    const hreflang = getHrefLang(lang);
+    const localizedPath = getLocalizedPath(lang, normalizedPath);
+    let element = document.querySelector(`link[rel="alternate"][hreflang="${hreflang}"]`) as HTMLLinkElement;
+
     if (!element) {
       element = document.createElement('link');
       element.setAttribute('rel', 'alternate');
       element.setAttribute('hreflang', hreflang);
       document.head.appendChild(element);
     }
-    
-    element.setAttribute('href', `${baseUrl}${pathname}?lang=${lang}`);
+
+    const href = `${baseUrl}${localizedPath === '/' ? '/' : localizedPath}`;
+    element.setAttribute('href', href);
   });
-  
-  let xDefault = document.querySelector('link[hreflang="x-default"]') as HTMLLinkElement;
+
+  let xDefault = document.querySelector('link[rel="alternate"][hreflang="x-default"]') as HTMLLinkElement;
   if (!xDefault) {
     xDefault = document.createElement('link');
     xDefault.setAttribute('rel', 'alternate');
     xDefault.setAttribute('hreflang', 'x-default');
     document.head.appendChild(xDefault);
   }
-  xDefault.setAttribute('href', `${baseUrl}${pathname}`);
+
+  const defaultHref = `${baseUrl}${normalizedPath === '/' ? '/' : normalizedPath}`;
+  xDefault.setAttribute('href', defaultHref);
 }
 
-function updateStructuredData(language: string, title: string, description: string) {
-  const structuredData = {
-    "@context": "https://schema.org",
-    "@type": "BeautySalon",
-    "name": "Magerovska Permanent",
-    "image": typeof window !== 'undefined' ? `${window.location.origin}/og-image.jpg` : '',
-    "description": description,
-    "address": {
-      "@type": "PostalAddress",
-      "addressLocality": "Kraków",
-      "addressCountry": "PL"
-    },
-    "geo": {
-      "@type": "GeoCoordinates",
-      "latitude": "50.0647",
-      "longitude": "19.9450"
-    },
-    "url": typeof window !== 'undefined' ? window.location.origin : '',
-    "telephone": "+48-XXX-XXX-XXX",
-    "priceRange": "$$",
-    "openingHoursSpecification": [
-      {
-        "@type": "OpeningHoursSpecification",
-        "dayOfWeek": ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday"],
-        "opens": "09:00",
-        "closes": "18:00"
-      }
-    ],
-    "areaServed": {
-      "@type": "City",
-      "name": "Kraków"
-    },
-    "makesOffer": [
-      {
-        "@type": "Offer",
-        "itemOffered": {
-          "@type": "Service",
-          "name": getServiceName(language, "eyebrows"),
-          "description": getServiceDescription(language, "eyebrows")
-        }
-      },
-      {
-        "@type": "Offer",
-        "itemOffered": {
-          "@type": "Service",
-          "name": getServiceName(language, "lips"),
-          "description": getServiceDescription(language, "lips")
-        }
-      },
-      {
-        "@type": "Offer",
-        "itemOffered": {
-          "@type": "Service",
-          "name": getServiceName(language, "eyeliner"),
-          "description": getServiceDescription(language, "eyeliner")
-        }
-      }
-    ]
-  };
+function updateStructuredData(
+  language: Language,
+  description: string,
+  baseUrl: string,
+  additionalData: Array<Record<string, any>>,
+) {
+  const localBusiness = createLocalBusinessData(language, description, baseUrl);
+  const combinedData = [localBusiness, ...additionalData];
 
-  let scriptTag = document.querySelector('script[type="application/ld+json"]');
-  
+  let scriptTag = document.querySelector('script[data-structured-data="primary"]');
+
   if (!scriptTag) {
     scriptTag = document.createElement('script');
     scriptTag.setAttribute('type', 'application/ld+json');
+    scriptTag.setAttribute('data-structured-data', 'primary');
     document.head.appendChild(scriptTag);
   }
-  
-  scriptTag.textContent = JSON.stringify(structuredData);
+
+  scriptTag.textContent = JSON.stringify(combinedData.length === 1 ? combinedData[0] : combinedData);
+}
+
+function createLocalBusinessData(language: Language, description: string, baseUrl: string) {
+  const socialProfiles = [
+    'https://instagram.com/magerovska_permanent',
+    'https://wa.me/380938203764',
+    'https://t.me/magerovska_permanent',
+    'https://theahstudio.booksy.com',
+  ];
+
+  const businessUrl = getLocalizedUrl(language, '/', baseUrl);
+  const offers = ['eyebrows', 'lips', 'eyeliner'].map((service) => {
+    const servicePath = `/services/${service}`;
+    const serviceUrl = getLocalizedUrl(language, servicePath, baseUrl);
+
+    return {
+      '@type': 'Offer',
+      'priceCurrency': 'PLN',
+      'price': getServicePrice(service),
+      'availability': 'https://schema.org/InStock',
+      'url': serviceUrl,
+      'itemOffered': {
+        '@type': 'Service',
+        'name': getServiceName(language, service),
+        'description': getServiceDescription(language, service),
+        'serviceType': getServiceName(language, service),
+        'url': serviceUrl,
+        'additionalProperty': [
+          {
+            '@type': 'PropertyValue',
+            'name': getLocalizedLabel(language, 'duration'),
+            'value': getServiceDuration(language, service),
+          },
+          {
+            '@type': 'PropertyValue',
+            'name': getLocalizedLabel(language, 'healing'),
+            'value': getServiceHealing(language, service),
+          },
+          {
+            '@type': 'PropertyValue',
+            'name': getLocalizedLabel(language, 'lasting'),
+            'value': getServiceLasting(language, service),
+          },
+        ],
+      },
+    };
+  });
+
+  return {
+    '@context': 'https://schema.org',
+    '@type': ['BeautySalon', 'LocalBusiness'],
+    '@id': `${businessUrl}#magerovska-permanent`,
+    'name': 'Magerovska Permanent',
+    'image': `${baseUrl}/og-image.jpg`,
+    'description': description,
+    'url': businessUrl,
+    'telephone': '+380938203764',
+    'priceRange': '200-500 PLN',
+    'address': {
+      '@type': 'PostalAddress',
+      'streetAddress': 'Kamienna 19b, lokal L3',
+      'addressLocality': 'Kraków',
+      'postalCode': '30-001',
+      'addressRegion': 'Małopolskie',
+      'addressCountry': 'PL',
+    },
+    'geo': {
+      '@type': 'GeoCoordinates',
+      'latitude': '50.074180',
+      'longitude': '19.944990',
+    },
+    'openingHoursSpecification': [
+      {
+        '@type': 'OpeningHoursSpecification',
+        'dayOfWeek': ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday'],
+        'opens': '09:00',
+        'closes': '18:00',
+      },
+    ],
+    'areaServed': {
+      '@type': 'City',
+      'name': 'Kraków',
+    },
+    'contactPoint': [
+      {
+        '@type': 'ContactPoint',
+        'telephone': '+380938203764',
+        'contactType': 'customer service',
+        'areaServed': ['PL', 'UA'],
+        'availableLanguage': ['pl', 'ru', 'uk', 'en'],
+      },
+    ],
+    'sameAs': socialProfiles,
+    'makesOffer': offers,
+  };
 }
 
 function getOGLocale(language: string): string {
@@ -245,4 +303,114 @@ function getServiceDescription(language: string, service: string): string {
     }
   };
   return descriptions[service]?.[language] || descriptions[service]?.en || '';
+}
+
+function getLocalizedLabel(language: string, key: ServiceLabelKey): string {
+  const labels: Record<ServiceLabelKey, Record<string, string>> = {
+    duration: {
+      ru: 'Длительность',
+      pl: 'Czas trwania',
+      en: 'Duration',
+      uk: 'Тривалість',
+    },
+    healing: {
+      ru: 'Заживление',
+      pl: 'Goienie',
+      en: 'Healing',
+      uk: 'Загоєння',
+    },
+    lasting: {
+      ru: 'Долговечность',
+      pl: 'Trwałość',
+      en: 'Longevity',
+      uk: 'Тривалість ефекту',
+    },
+  };
+
+  return labels[key][language] || labels[key].en;
+}
+
+function getServiceDuration(language: string, service: string): string {
+  const durations: Record<string, Record<string, string>> = {
+    eyebrows: {
+      ru: '2-3 часа',
+      pl: '2-3 godziny',
+      en: '2-3 hours',
+      uk: '2-3 години',
+    },
+    lips: {
+      ru: '2-2.5 часа',
+      pl: '2-2.5 godziny',
+      en: '2-2.5 hours',
+      uk: '2-2.5 години',
+    },
+    eyeliner: {
+      ru: '1.5-2 часа',
+      pl: '1.5-2 godziny',
+      en: '1.5-2 hours',
+      uk: '1.5-2 години',
+    },
+  };
+
+  return durations[service]?.[language] || durations[service]?.en || '';
+}
+
+function getServiceHealing(language: string, service: string): string {
+  const healing: Record<string, Record<string, string>> = {
+    eyebrows: {
+      ru: '7-14 дней',
+      pl: '7-14 dni',
+      en: '7-14 days',
+      uk: '7-14 днів',
+    },
+    lips: {
+      ru: '5-7 дней',
+      pl: '5-7 dni',
+      en: '5-7 days',
+      uk: '5-7 днів',
+    },
+    eyeliner: {
+      ru: '3-5 дней',
+      pl: '3-5 dni',
+      en: '3-5 days',
+      uk: '3-5 днів',
+    },
+  };
+
+  return healing[service]?.[language] || healing[service]?.en || '';
+}
+
+function getServiceLasting(language: string, service: string): string {
+  const lasting: Record<string, Record<string, string>> = {
+    eyebrows: {
+      ru: '1-2 года',
+      pl: '1-2 lata',
+      en: '1-2 years',
+      uk: '1-2 роки',
+    },
+    lips: {
+      ru: '1-1.5 года',
+      pl: '1-1.5 roku',
+      en: '1-1.5 years',
+      uk: '1-1.5 року',
+    },
+    eyeliner: {
+      ru: '2-3 года',
+      pl: '2-3 lata',
+      en: '2-3 years',
+      uk: '2-3 роки',
+    },
+  };
+
+  return lasting[service]?.[language] || lasting[service]?.en || '';
+}
+
+function getServicePrice(service: string): string {
+  const prices: Record<string, string> = {
+    eyebrows: '450',
+    lips: '450',
+    eyeliner: '350',
+  };
+
+  return prices[service] || '0';
 }

--- a/client/src/contexts/LanguageContext.tsx
+++ b/client/src/contexts/LanguageContext.tsx
@@ -177,7 +177,9 @@ const translations = {
   'notfound.title': 'Страница не найдена',
   'notfound.description': 'Похоже, вы попали на несуществующую страницу. Воспользуйтесь кнопками ниже, чтобы вернуться на сайт.',
   'notfound.backHome': 'На главную',
+  'notfound.homeLabel': 'Вернуться на главную страницу',
   'notfound.contact': 'Связаться с мастером',
+  'notfound.contactLabel': 'Перейти к разделу контактов',
   },
   pl: {
     // Navigation
@@ -311,7 +313,9 @@ const translations = {
   'notfound.title': 'Strona nie została znaleziona',
   'notfound.description': 'Wygląda na to, że ta strona nie istnieje. Skorzystaj z przycisków poniżej, aby wrócić na stronę główną.',
   'notfound.backHome': 'Wróć na stronę główną',
+  'notfound.homeLabel': 'Powrót na stronę główną',
   'notfound.contact': 'Skontaktuj się z nami',
+  'notfound.contactLabel': 'Przejdź do sekcji kontaktów',
   // Process
   'process.title': 'Proces',
   'process.step1.title': 'Konsultacja',
@@ -480,7 +484,9 @@ const translations = {
   'notfound.title': 'Page not found',
   'notfound.description': 'It looks like this page does not exist. Use the options below to get back on track.',
   'notfound.backHome': 'Back to homepage',
+  'notfound.homeLabel': 'Return to the homepage',
   'notfound.contact': 'Contact the artist',
+  'notfound.contactLabel': 'Jump to the contact section',
   // Process
   'process.title': 'Process',
   'process.step1.title': 'Consultation',
@@ -683,7 +689,9 @@ const translations = {
     'notfound.title': 'Сторінку не знайдено',
     'notfound.description': 'Здається, цієї сторінки не існує. Скористайтеся кнопками нижче, щоб повернутися на сайт.',
     'notfound.backHome': 'Повернутися на головну',
+    'notfound.homeLabel': 'Повернутися на головну сторінку',
     'notfound.contact': 'Зв’язатися з майстром',
+    'notfound.contactLabel': 'Перейти до розділу контактів',
   },
 };
 

--- a/client/src/contexts/LanguageContext.tsx
+++ b/client/src/contexts/LanguageContext.tsx
@@ -17,6 +17,10 @@ const translations = {
     'nav.portfolio': 'Портфолио',
     'nav.pricing': 'Цены',
     'nav.contact': 'Контакты',
+    'breadcrumbs.label': 'Хлебные крошки',
+    'breadcrumbs.home': 'Главная',
+    'breadcrumbs.services': 'Услуги',
+    'breadcrumbs.back': 'Назад на главную',
     
     // Hero
     'hero.title': 'Перманентный макияж, который выглядит естественно — как вы',
@@ -24,6 +28,7 @@ const translations = {
     'hero.slogan': 'Перманентный макияж, который выглядит естественно — как вы. Брови, губы, межресничка в Кракове.',
     'hero.cta': 'Записаться на процедуру',
     'hero.brand': 'MAGEROVSKA PERMANENT',
+    'hero.imageAlt': 'Клиентка после процедуры перманентного макияжа в студии Magerovska Permanent',
     
     // Site Title
     'site.title': 'Magerovska Permanent | Перманентный макияж в Кракове',
@@ -169,6 +174,10 @@ const translations = {
   'faq.item.4.answer': 'Да, есть ряд ограничений: беременность и лактация, онкология, сахарный диабет 1 типа, нарушения свертываемости крови, келоидные рубцы, острые воспалительные процессы. На консультации обязательно обсуждаем все нюансы и противопоказания.',
   'faq.item.5.question': 'Нужна ли коррекция?',
   'faq.item.5.answer': 'Коррекция рекомендуется через 4-6 недель после первой процедуры для достижения идеального результата. Это нормальная практика, так как кожа у всех заживает по-разному. В большинстве случаев одной коррекции достаточно на весь период носки.',
+  'notfound.title': 'Страница не найдена',
+  'notfound.description': 'Похоже, вы попали на несуществующую страницу. Воспользуйтесь кнопками ниже, чтобы вернуться на сайт.',
+  'notfound.backHome': 'На главную',
+  'notfound.contact': 'Связаться с мастером',
   },
   pl: {
     // Navigation
@@ -176,6 +185,10 @@ const translations = {
     'nav.portfolio': 'Portfolio',
     'nav.pricing': 'Cennik',
     'nav.contact': 'Kontakt',
+    'breadcrumbs.label': 'Okruszki nawigacyjne',
+    'breadcrumbs.home': 'Strona główna',
+    'breadcrumbs.services': 'Usługi',
+    'breadcrumbs.back': 'Powrót na stronę główną',
     
     // Hero
     'hero.title': 'Makijaż permanentny, który wygląda naturalnie — jak Ty',
@@ -183,6 +196,7 @@ const translations = {
     'hero.slogan': 'Makijaż permanentny, który wygląda naturalnie — jak Ty. Brwi, usta, kreska w Krakowie.',
     'hero.cta': 'Umów zabieg',
     'hero.brand': 'MAGEROVSKA PERMANENT',
+    'hero.imageAlt': 'Klientka po zabiegu makijażu permanentnego w studio Magerovska Permanent',
     
     // Site Title
     'site.title': 'Magerovska Permanent | Makijaż permanentny w Krakowie',
@@ -294,8 +308,10 @@ const translations = {
     'footer.hoursValue': 'Pn-Pt: 9:00-18:00',
     'footer.copyright': '© 2025 Magerovska Permanent. Wszystkie prawa zastrzeżone.',
   // Not Found
-  'notfound.title': '404 Strona nie znaleziona',
-  'notfound.description': 'Czy вы забыли добавить страницу в маршрутизатор?',
+  'notfound.title': 'Strona nie została znaleziona',
+  'notfound.description': 'Wygląda na to, że ta strona nie istnieje. Skorzystaj z przycisków poniżej, aby wrócić na stronę główną.',
+  'notfound.backHome': 'Wróć na stronę główną',
+  'notfound.contact': 'Skontaktuj się z nami',
   // Process
   'process.title': 'Proces',
   'process.step1.title': 'Konsultacja',
@@ -338,6 +354,10 @@ const translations = {
     'nav.portfolio': 'Portfolio',
     'nav.pricing': 'Pricing',
     'nav.contact': 'Contact',
+    'breadcrumbs.label': 'Breadcrumb navigation',
+    'breadcrumbs.home': 'Home',
+    'breadcrumbs.services': 'Services',
+    'breadcrumbs.back': 'Back to homepage',
     
     // Hero
     'hero.title': 'Permanent makeup that looks natural — like you',
@@ -345,6 +365,7 @@ const translations = {
     'hero.slogan': 'Permanent makeup that looks natural — like you. Eyebrows, lips, eyeliner in Krakow.',
     'hero.cta': 'Book procedure',
     'hero.brand': 'MAGEROVSKA PERMANENT',
+    'hero.imageAlt': 'Client showcasing healed permanent makeup at the Magerovska Permanent studio in Kraków',
     
     // Site Title
     'site.title': 'Magerovska Permanent | Permanent Makeup in Krakow',
@@ -456,8 +477,10 @@ const translations = {
     'footer.hoursValue': 'Mon-Fri: 9:00-18:00',
     'footer.copyright': '© 2025 Magerovska Permanent. All rights reserved.',
   // Not Found
-  'notfound.title': '404 Page Not Found',
-  'notfound.description': 'Did you forget to add the page to the router?',
+  'notfound.title': 'Page not found',
+  'notfound.description': 'It looks like this page does not exist. Use the options below to get back on track.',
+  'notfound.backHome': 'Back to homepage',
+  'notfound.contact': 'Contact the artist',
   // Process
   'process.title': 'Process',
   'process.step1.title': 'Consultation',
@@ -500,6 +523,10 @@ const translations = {
     'nav.portfolio': 'Портфоліо',
     'nav.pricing': 'Ціни',
     'nav.contact': 'Контакти',
+    'breadcrumbs.label': 'Навігаційний ланцюжок',
+    'breadcrumbs.home': 'Головна',
+    'breadcrumbs.services': 'Послуги',
+    'breadcrumbs.back': 'Повернутися на головну',
     
     // Hero
     'hero.title': 'Перманентний макіяж, що виглядає природньо — як ви',
@@ -507,6 +534,7 @@ const translations = {
     'hero.slogan': 'Перманентний макіяж, що виглядає природньо — як ви. Брови, губи, міжвійкова в Києві.',
     'hero.cta': 'Записатися на процедуру',
     'hero.brand': 'MAGEROVSKA PERMANENT',
+    'hero.imageAlt': 'Клієнтка після процедури перманентного макіяжу у студії Magerovska Permanent',
     
     // Site Title
     'site.title': 'Magerovska Permanent | Перманентний макіяж у Кракові та Києві',
@@ -652,6 +680,10 @@ const translations = {
     'faq.item.4.answer': 'Так, є ряд обмежень: вагітність і лактація, онкологія, цукровий діабет 1 типу, порушення згортання крові, келоїдні рубці, гострі запальні процеси. На консультації обов\'язково обговорюємо усі нюанси та протипоказання.',
     'faq.item.5.question': 'Чи потрібна корекція?',
     'faq.item.5.answer': 'Корекція рекомендується через 4-6 тижнів після першої процедури для досягнення ідеального результату. Це нормальна практика, оскільки шкіра у всіх загоюється по-різному. У більшості випадків однієї корекції вистачає на весь період носіння.',
+    'notfound.title': 'Сторінку не знайдено',
+    'notfound.description': 'Здається, цієї сторінки не існує. Скористайтеся кнопками нижче, щоб повернутися на сайт.',
+    'notfound.backHome': 'Повернутися на головну',
+    'notfound.contact': 'Зв’язатися з майстром',
   },
 };
 

--- a/client/src/pages/eyebrows.tsx
+++ b/client/src/pages/eyebrows.tsx
@@ -8,8 +8,10 @@ import Contact from "@/components/contact";
 import Footer from "@/components/footer";
 import SEO from "@/components/seo";
 import { useLanguage } from "@/contexts/LanguageContext";
+import { getLocalizedPath, getLocalizedUrl } from "@/utils/languagePaths";
 import { Button } from "@/components/ui/button";
-import { ChevronRight, Clock, Star, Shield } from "lucide-react";
+import { ChevronRight, Clock, Star, Shield, ArrowLeft } from "lucide-react";
+import { Link } from "wouter";
 
 export default function Eyebrows() {
   const { t, language } = useLanguage();
@@ -120,25 +122,89 @@ export default function Eyebrows() {
   const seo = getSEOData();
   const hero = getHeroData();
   const benefits = getBenefits();
+  const localizedHomePath = getLocalizedPath(language, "/");
+  const servicesAnchor = localizedHomePath === "/" ? "/#services" : `${localizedHomePath}#services`;
+  const canonicalUrl = getLocalizedUrl(language, "/services/eyebrows");
+  const businessUrl = getLocalizedUrl(language, "/");
 
   const scrollToContact = () => {
     document.getElementById('contact')?.scrollIntoView({ behavior: 'smooth' });
   };
 
+  const serviceOffers = [
+    { name: t('pricing.eyebrows.service.powder'), price: '450' },
+    { name: t('pricing.eyebrows.service.ombre'), price: '500' },
+    { name: t('pricing.eyebrows.service.correction'), price: '150' },
+  ];
+
+  const serviceStructuredData = [
+    {
+      '@context': 'https://schema.org',
+      '@type': 'Service',
+      '@id': `${canonicalUrl}#service`,
+      'name': seo.title,
+      'serviceType': hero.title,
+      'description': seo.description,
+      'provider': {
+        '@type': 'LocalBusiness',
+        'name': 'Magerovska Permanent',
+        '@id': `${businessUrl}#magerovska-permanent`,
+      },
+      'areaServed': {
+        '@type': 'City',
+        'name': 'Kraków',
+      },
+      'offers': serviceOffers.map((offer) => ({
+        '@type': 'Offer',
+        'name': offer.name,
+        'price': offer.price,
+        'priceCurrency': 'PLN',
+        'availability': 'https://schema.org/InStock',
+        'url': canonicalUrl,
+      })),
+      'additionalProperty': [
+        { '@type': 'PropertyValue', 'name': t('services.label.duration'), 'value': t('services.eyebrows.duration') },
+        { '@type': 'PropertyValue', 'name': t('services.label.healing'), 'value': t('services.eyebrows.healing') },
+        { '@type': 'PropertyValue', 'name': t('services.label.lasting'), 'value': t('services.eyebrows.lasting') },
+      ],
+    },
+  ];
+
   return (
     <>
-      <SEO 
+      <SEO
         title={seo.title}
         description={seo.description}
         keywords={seo.keywords}
-        canonicalUrl="https://magerovska.com/services/eyebrows"
+        canonicalUrl={canonicalUrl}
+        structuredData={serviceStructuredData}
       />
       <div className="min-h-screen">
         <Navigation />
-        
+
         {/* Hero Section */}
         <section className="pt-32 pb-20 px-4 bg-gradient-to-b from-background to-accent/5">
           <div className="max-w-6xl mx-auto">
+            <div className="mb-8 text-sm text-muted-foreground">
+              <nav aria-label={t('breadcrumbs.label')} className="flex flex-wrap items-center gap-2">
+                <Link href={localizedHomePath} className="text-foreground hover:underline">
+                  {t('breadcrumbs.home')}
+                </Link>
+                <span className="text-muted-foreground">/</span>
+                <a href={servicesAnchor} className="text-foreground hover:underline">
+                  {t('breadcrumbs.services')}
+                </a>
+                <span className="text-muted-foreground">/</span>
+                <span className="font-medium text-foreground">{hero.title}</span>
+              </nav>
+              <Link
+                href={localizedHomePath}
+                className="mt-4 inline-flex items-center gap-2 text-sm text-accent hover:underline"
+              >
+                <ArrowLeft className="h-4 w-4" />
+                {t('breadcrumbs.back')}
+              </Link>
+            </div>
             <div className="text-center fade-in">
               <h1 className="text-5xl md:text-6xl font-serif font-bold mb-6 text-foreground" data-testid="text-page-title">
                 {hero.title}

--- a/client/src/pages/eyeliner.tsx
+++ b/client/src/pages/eyeliner.tsx
@@ -8,8 +8,10 @@ import Contact from "@/components/contact";
 import Footer from "@/components/footer";
 import SEO from "@/components/seo";
 import { useLanguage } from "@/contexts/LanguageContext";
+import { getLocalizedPath, getLocalizedUrl } from "@/utils/languagePaths";
 import { Button } from "@/components/ui/button";
-import { ChevronRight, Eye, Clock, Sparkles } from "lucide-react";
+import { ChevronRight, Eye, Clock, Sparkles, ArrowLeft } from "lucide-react";
+import { Link } from "wouter";
 
 export default function Eyeliner() {
   const { t, language } = useLanguage();
@@ -120,18 +122,62 @@ export default function Eyeliner() {
   const seo = getSEOData();
   const hero = getHeroData();
   const benefits = getBenefits();
+  const localizedHomePath = getLocalizedPath(language, "/");
+  const servicesAnchor = localizedHomePath === "/" ? "/#services" : `${localizedHomePath}#services`;
+  const canonicalUrl = getLocalizedUrl(language, "/services/eyeliner");
+  const businessUrl = getLocalizedUrl(language, "/");
 
   const scrollToContact = () => {
     document.getElementById('contact')?.scrollIntoView({ behavior: 'smooth' });
   };
 
+  const serviceOffers = [
+    { name: t('pricing.eyeliner.service.upper'), price: '350' },
+    { name: t('pricing.eyeliner.service.lower'), price: '200' },
+    { name: t('pricing.eyeliner.service.correction'), price: '100' },
+  ];
+
+  const serviceStructuredData = [
+    {
+      '@context': 'https://schema.org',
+      '@type': 'Service',
+      '@id': `${canonicalUrl}#service`,
+      'name': seo.title,
+      'serviceType': hero.title,
+      'description': seo.description,
+      'provider': {
+        '@type': 'LocalBusiness',
+        'name': 'Magerovska Permanent',
+        '@id': `${businessUrl}#magerovska-permanent`,
+      },
+      'areaServed': {
+        '@type': 'City',
+        'name': 'Kraków',
+      },
+      'offers': serviceOffers.map((offer) => ({
+        '@type': 'Offer',
+        'name': offer.name,
+        'price': offer.price,
+        'priceCurrency': 'PLN',
+        'availability': 'https://schema.org/InStock',
+        'url': canonicalUrl,
+      })),
+      'additionalProperty': [
+        { '@type': 'PropertyValue', 'name': t('services.label.duration'), 'value': t('services.eyeliner.duration') },
+        { '@type': 'PropertyValue', 'name': t('services.label.healing'), 'value': t('services.eyeliner.healing') },
+        { '@type': 'PropertyValue', 'name': t('services.label.lasting'), 'value': t('services.eyeliner.lasting') },
+      ],
+    },
+  ];
+
   return (
     <>
-      <SEO 
+      <SEO
         title={seo.title}
         description={seo.description}
         keywords={seo.keywords}
-        canonicalUrl="https://magerovska.com/services/eyeliner"
+        canonicalUrl={canonicalUrl}
+        structuredData={serviceStructuredData}
       />
       <div className="min-h-screen">
         <Navigation />
@@ -139,6 +185,26 @@ export default function Eyeliner() {
         {/* Hero Section */}
         <section className="pt-32 pb-20 px-4 bg-gradient-to-b from-background to-accent/5">
           <div className="max-w-6xl mx-auto">
+            <div className="mb-8 text-sm text-muted-foreground">
+              <nav aria-label={t('breadcrumbs.label')} className="flex flex-wrap items-center gap-2">
+                <Link href={localizedHomePath} className="text-foreground hover:underline">
+                  {t('breadcrumbs.home')}
+                </Link>
+                <span className="text-muted-foreground">/</span>
+                <a href={servicesAnchor} className="text-foreground hover:underline">
+                  {t('breadcrumbs.services')}
+                </a>
+                <span className="text-muted-foreground">/</span>
+                <span className="font-medium text-foreground">{hero.title}</span>
+              </nav>
+              <Link
+                href={localizedHomePath}
+                className="mt-4 inline-flex items-center gap-2 text-sm text-accent hover:underline"
+              >
+                <ArrowLeft className="h-4 w-4" />
+                {t('breadcrumbs.back')}
+              </Link>
+            </div>
             <div className="text-center fade-in">
               <h1 className="text-5xl md:text-6xl font-serif font-bold mb-6 text-foreground" data-testid="text-page-title">
                 {hero.title}

--- a/client/src/pages/lips.tsx
+++ b/client/src/pages/lips.tsx
@@ -8,8 +8,10 @@ import Contact from "@/components/contact";
 import Footer from "@/components/footer";
 import SEO from "@/components/seo";
 import { useLanguage } from "@/contexts/LanguageContext";
+import { getLocalizedPath, getLocalizedUrl } from "@/utils/languagePaths";
 import { Button } from "@/components/ui/button";
-import { ChevronRight, Sparkles, Heart, Palette } from "lucide-react";
+import { ChevronRight, Sparkles, Heart, Palette, ArrowLeft } from "lucide-react";
+import { Link } from "wouter";
 
 export default function Lips() {
   const { t, language } = useLanguage();
@@ -120,18 +122,62 @@ export default function Lips() {
   const seo = getSEOData();
   const hero = getHeroData();
   const benefits = getBenefits();
+  const localizedHomePath = getLocalizedPath(language, "/");
+  const servicesAnchor = localizedHomePath === "/" ? "/#services" : `${localizedHomePath}#services`;
+  const canonicalUrl = getLocalizedUrl(language, "/services/lips");
+  const businessUrl = getLocalizedUrl(language, "/");
 
   const scrollToContact = () => {
     document.getElementById('contact')?.scrollIntoView({ behavior: 'smooth' });
   };
 
+  const serviceOffers = [
+    { name: t('pricing.lips.service.lipBlush'), price: '450' },
+    { name: t('pricing.lips.service.contour'), price: '350' },
+    { name: t('pricing.lips.service.correction'), price: '120' },
+  ];
+
+  const serviceStructuredData = [
+    {
+      '@context': 'https://schema.org',
+      '@type': 'Service',
+      '@id': `${canonicalUrl}#service`,
+      'name': seo.title,
+      'serviceType': hero.title,
+      'description': seo.description,
+      'provider': {
+        '@type': 'LocalBusiness',
+        'name': 'Magerovska Permanent',
+        '@id': `${businessUrl}#magerovska-permanent`,
+      },
+      'areaServed': {
+        '@type': 'City',
+        'name': 'Kraków',
+      },
+      'offers': serviceOffers.map((offer) => ({
+        '@type': 'Offer',
+        'name': offer.name,
+        'price': offer.price,
+        'priceCurrency': 'PLN',
+        'availability': 'https://schema.org/InStock',
+        'url': canonicalUrl,
+      })),
+      'additionalProperty': [
+        { '@type': 'PropertyValue', 'name': t('services.label.duration'), 'value': t('services.lips.duration') },
+        { '@type': 'PropertyValue', 'name': t('services.label.healing'), 'value': t('services.lips.healing') },
+        { '@type': 'PropertyValue', 'name': t('services.label.lasting'), 'value': t('services.lips.lasting') },
+      ],
+    },
+  ];
+
   return (
     <>
-      <SEO 
+      <SEO
         title={seo.title}
         description={seo.description}
         keywords={seo.keywords}
-        canonicalUrl="https://magerovska.com/services/lips"
+        canonicalUrl={canonicalUrl}
+        structuredData={serviceStructuredData}
       />
       <div className="min-h-screen">
         <Navigation />
@@ -139,6 +185,26 @@ export default function Lips() {
         {/* Hero Section */}
         <section className="pt-32 pb-20 px-4 bg-gradient-to-b from-background to-accent/5">
           <div className="max-w-6xl mx-auto">
+            <div className="mb-8 text-sm text-muted-foreground">
+              <nav aria-label={t('breadcrumbs.label')} className="flex flex-wrap items-center gap-2">
+                <Link href={localizedHomePath} className="text-foreground hover:underline">
+                  {t('breadcrumbs.home')}
+                </Link>
+                <span className="text-muted-foreground">/</span>
+                <a href={servicesAnchor} className="text-foreground hover:underline">
+                  {t('breadcrumbs.services')}
+                </a>
+                <span className="text-muted-foreground">/</span>
+                <span className="font-medium text-foreground">{hero.title}</span>
+              </nav>
+              <Link
+                href={localizedHomePath}
+                className="mt-4 inline-flex items-center gap-2 text-sm text-accent hover:underline"
+              >
+                <ArrowLeft className="h-4 w-4" />
+                {t('breadcrumbs.back')}
+              </Link>
+            </div>
             <div className="text-center fade-in">
               <h1 className="text-5xl md:text-6xl font-serif font-bold mb-6 text-foreground" data-testid="text-page-title">
                 {hero.title}

--- a/client/src/pages/localized-page.tsx
+++ b/client/src/pages/localized-page.tsx
@@ -1,0 +1,25 @@
+import type { ComponentType } from 'react';
+import { useEffect } from 'react';
+import type { RouteComponentProps } from 'wouter';
+import { useLanguage } from '@/contexts/LanguageContext';
+import { resolveLanguageFromSegment } from '@/utils/languagePaths';
+
+type LangRouteParams = {
+  lang?: string;
+};
+
+export function withLocalizedLanguage(Component: ComponentType<any>) {
+  return function LocalizedRoute({ params }: RouteComponentProps<LangRouteParams>) {
+    const { setLanguage } = useLanguage();
+    const langFromRoute = params?.lang;
+
+    useEffect(() => {
+      const resolved = resolveLanguageFromSegment(langFromRoute);
+      if (resolved) {
+        setLanguage(resolved);
+      }
+    }, [langFromRoute, setLanguage]);
+
+    return <Component />;
+  };
+}

--- a/client/src/pages/not-found.tsx
+++ b/client/src/pages/not-found.tsx
@@ -1,24 +1,56 @@
 import { Card, CardContent } from "@/components/ui/card";
-import { AlertCircle } from "lucide-react";
+import { AlertCircle, ArrowLeft, MessageCircle } from "lucide-react";
 import { useLanguage } from "@/contexts/LanguageContext";
+import { getLocalizedPath } from "@/utils/languagePaths";
+import Navigation from "@/components/navigation";
+import Footer from "@/components/footer";
+import SEO from "@/components/seo";
+import { Button } from "@/components/ui/button";
+import { Link } from "wouter";
 
 export default function NotFound() {
-  const { t } = useLanguage();
+  const { t, language } = useLanguage();
+  const localizedHomePath = getLocalizedPath(language, "/");
+  const contactHref = localizedHomePath === "/" ? "/#contact" : `${localizedHomePath}#contact`;
 
   return (
-    <div className="min-h-screen w-full flex items-center justify-center bg-gray-50">
-      <Card className="w-full max-w-md mx-4">
-        <CardContent className="pt-6">
-          <div className="flex mb-4 gap-2">
-            <AlertCircle className="h-8 w-8 text-red-500" />
-            <h1 className="text-2xl font-bold text-gray-900">{t('notfound.title')}</h1>
-          </div>
-
-          <p className="mt-4 text-sm text-gray-600">
-            {t('notfound.description')}
-          </p>
-        </CardContent>
-      </Card>
-    </div>
+    <>
+      <SEO
+        title={`404 | ${t('site.title')}`}
+        description={t('notfound.description')}
+        canonicalUrl="https://magerovska.com/404"
+      />
+      <div className="min-h-screen flex flex-col bg-gray-50">
+        <Navigation />
+        <main className="flex-1 flex items-center justify-center px-4 py-16">
+          <Card className="w-full max-w-xl shadow-lg">
+            <CardContent className="pt-10 pb-12">
+              <div className="flex flex-col items-center text-center gap-6">
+                <div className="flex items-center gap-3">
+                  <AlertCircle className="h-10 w-10 text-red-500" aria-hidden="true" />
+                  <h1 className="text-3xl font-semibold text-gray-900">{t('notfound.title')}</h1>
+                </div>
+                <p className="text-base text-gray-600 max-w-lg">{t('notfound.description')}</p>
+                <div className="flex flex-col sm:flex-row gap-4 w-full sm:justify-center">
+                  <Link href={localizedHomePath} className="flex-1 sm:flex-none">
+                    <Button className="w-full">
+                      <ArrowLeft className="h-4 w-4" />
+                      {t('notfound.backHome')}
+                    </Button>
+                  </Link>
+                  <Button asChild variant="outline" className="flex-1 sm:flex-none">
+                    <a href={contactHref}>
+                      <MessageCircle className="h-4 w-4" />
+                      {t('notfound.contact')}
+                    </a>
+                  </Button>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        </main>
+        <Footer />
+      </div>
+    </>
   );
 }

--- a/client/src/pages/not-found.tsx
+++ b/client/src/pages/not-found.tsx
@@ -32,14 +32,18 @@ export default function NotFound() {
                 </div>
                 <p className="text-base text-gray-600 max-w-lg">{t('notfound.description')}</p>
                 <div className="flex flex-col sm:flex-row gap-4 w-full sm:justify-center">
-                  <Link href={localizedHomePath} className="flex-1 sm:flex-none">
+                  <Link
+                    href={localizedHomePath}
+                    className="flex-1 sm:flex-none"
+                    aria-label={t('notfound.homeLabel')}
+                  >
                     <Button className="w-full">
                       <ArrowLeft className="h-4 w-4" />
                       {t('notfound.backHome')}
                     </Button>
                   </Link>
                   <Button asChild variant="outline" className="flex-1 sm:flex-none">
-                    <a href={contactHref}>
+                    <a href={contactHref} aria-label={t('notfound.contactLabel')}>
                       <MessageCircle className="h-4 w-4" />
                       {t('notfound.contact')}
                     </a>

--- a/client/src/utils/languagePaths.ts
+++ b/client/src/utils/languagePaths.ts
@@ -1,0 +1,74 @@
+import { Language } from '@/contexts/LanguageContext';
+
+const LANGUAGE_SLUGS: Record<Language, string> = {
+  ru: '',
+  pl: 'pl',
+  en: 'en',
+  uk: 'ua',
+};
+
+const SEGMENT_TO_LANGUAGE: Record<string, Language> = {
+  ru: 'ru',
+  pl: 'pl',
+  en: 'en',
+  ua: 'uk',
+  uk: 'uk',
+};
+
+const LOCALE_PREFIX_PATTERN = /^\/(ru|pl|en|ua|uk)(?=\/|$)/i;
+
+export function getLanguageSlug(language: Language): string {
+  return LANGUAGE_SLUGS[language];
+}
+
+export function getHrefLang(language: Language): string {
+  return language === 'uk' ? 'ua' : language;
+}
+
+export function getLocalizedPath(language: Language, path: string): string {
+  const slug = getLanguageSlug(language);
+  const normalizedPath = path.startsWith('/') ? path : `/${path}`;
+
+  if (!slug) {
+    return normalizedPath === '/' ? '/' : normalizedPath;
+  }
+
+  if (normalizedPath === '/') {
+    return `/${slug}`;
+  }
+
+  return `/${slug}${normalizedPath}`;
+}
+
+export function getLocalizedUrl(language: Language, path: string, baseUrl = 'https://magerovska.com'): string {
+  const localizedPath = getLocalizedPath(language, path);
+  if (localizedPath === '/') {
+    return baseUrl;
+  }
+  return `${baseUrl}${localizedPath}`;
+}
+
+export function stripLocaleFromPath(pathname: string): string {
+  if (!pathname) {
+    return '/';
+  }
+
+  const match = pathname.match(LOCALE_PREFIX_PATTERN);
+  if (match) {
+    const stripped = pathname.replace(LOCALE_PREFIX_PATTERN, '');
+    return stripped === '' ? '/' : stripped;
+  }
+
+  return pathname;
+}
+
+export function resolveLanguageFromSegment(segment?: string): Language | undefined {
+  if (!segment) {
+    return undefined;
+  }
+
+  const normalized = segment.toLowerCase();
+  return SEGMENT_TO_LANGUAGE[normalized];
+}
+
+export const SUPPORTED_LANGUAGE_SEGMENTS = Object.keys(SEGMENT_TO_LANGUAGE);

--- a/client/src/utils/languagePaths.ts
+++ b/client/src/utils/languagePaths.ts
@@ -22,7 +22,7 @@ export function getLanguageSlug(language: Language): string {
 }
 
 export function getHrefLang(language: Language): string {
-  return language === 'uk' ? 'ua' : language;
+  return language === 'uk' ? 'uk' : language;
 }
 
 export function getLocalizedPath(language: Language, path: string): string {

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1,5 +1,7 @@
 import type { Express } from "express";
 import { createServer, type Server } from "http";
+import path from "path";
+import fs from "fs";
 import { storage } from "./storage";
 import { insertContactSubmissionSchema } from "@shared/schema";
 import { z } from "zod";
@@ -71,6 +73,34 @@ export async function registerRoutes(app: Express): Promise<Server> {
         message: "Internal server error"
       });
     }
+  });
+
+  const distIndex = path.resolve(import.meta.dirname, "public", "index.html");
+
+  app.get(/^\/services(\/.*)?$/, (req, res, next) => {
+    if (app.get("env") === "development") {
+      return next();
+    }
+
+    if (fs.existsSync(distIndex)) {
+      res.sendFile(distIndex);
+      return;
+    }
+
+    next();
+  });
+
+  app.get(/^\/(ru|pl|en|ua|uk)(\/.*)?$/, (req, res, next) => {
+    if (app.get("env") === "development") {
+      return next();
+    }
+
+    if (fs.existsSync(distIndex)) {
+      res.sendFile(distIndex);
+      return;
+    }
+
+    next();
   });
 
   const httpServer = createServer(app);


### PR DESCRIPTION
## Summary
- add static hreflang alternates and LocalBusiness JSON-LD to the base HTML shell
- introduce utilities and localized route wrappers so language-prefixed URLs render the SPA and emit correct canonicals and structured data
- update navigation, service pages, and the 404 view to respect localized paths and smooth navigation back to the homepage

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68e506e329d8832785386853cbbc882a